### PR TITLE
Add moving average function with tests

### DIFF
--- a/moving_average.py
+++ b/moving_average.py
@@ -1,0 +1,29 @@
+from typing import Iterable, List
+
+def moving_average(data: Iterable[float], window_size: int) -> List[float]:
+    """Compute the moving average of a sequence of numbers.
+
+    Args:
+        data: Iterable of numeric values.
+        window_size: Size of the moving window. Must be a positive integer.
+
+    Returns:
+        A list of moving averages. If the data has fewer elements than the
+        window size, an empty list is returned.
+
+    Raises:
+        ValueError: If ``window_size`` is not a positive integer.
+    """
+    if window_size <= 0:
+        raise ValueError("window_size must be a positive integer")
+
+    values = list(data)
+    if len(values) < window_size:
+        return []
+
+    window_sum = sum(values[:window_size])
+    averages = [window_sum / window_size]
+    for i in range(window_size, len(values)):
+        window_sum += values[i] - values[i - window_size]
+        averages.append(window_sum / window_size)
+    return averages

--- a/tests/test_moving_average.py
+++ b/tests/test_moving_average.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+import pytest
+
+# Ensure the repository root is in the Python path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from moving_average import moving_average
+
+
+def test_moving_average_basic():
+    data = [1, 2, 3, 4, 5]
+    assert moving_average(data, 3) == [2.0, 3.0, 4.0]
+
+
+def test_window_size_one():
+    data = [10, 20]
+    assert moving_average(data, 1) == [10.0, 20.0]
+
+
+def test_invalid_window_size():
+    with pytest.raises(ValueError):
+        moving_average([1, 2, 3], 0)
+
+
+def test_window_larger_than_data():
+    assert moving_average([1, 2], 3) == []


### PR DESCRIPTION
## Summary
- implement a standalone `moving_average` utility for computing moving averages
- add pytest-based unit tests for typical and edge-case scenarios

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68918d2765548320b3db98e782ad87fb