### PR TITLE
Add Python eligibility engine

### DIFF
--- a/EligibilityCalculator.json
+++ b/EligibilityCalculator.json
@@ -1,0 +1,14 @@
+{
+  "engineering": {
+    "gpa": 85,
+    "qudrat": 65,
+    "tahseely": 65,
+    "ielts": 6.0
+  },
+  "non_engineering": {
+    "gpa": 80,
+    "qudrat": 60,
+    "tahseely": 60,
+    "ielts": 6.0
+  }
+}

--- a/EligibilityEngine.py
+++ b/EligibilityEngine.py
@@ -1,0 +1,62 @@
+"""Simple eligibility computation based on JSON-defined criteria.
+
+This module loads eligibility rules from ``EligibilityCalculator.json`` and
+provides a helper function :func:`check_eligibility` to evaluate whether a
+candidate meets the requirements for engineering or non-engineering tracks.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+import json
+
+
+CRITERIA_PATH = Path(__file__).with_name("EligibilityCalculator.json")
+
+
+@dataclass
+class EligibilityResult:
+    """Result of an eligibility check."""
+
+    eligible: bool
+    track: Optional[str] = None
+
+
+class EligibilityEngine:
+    """Evaluate candidate data against admission criteria."""
+
+    def __init__(self, criteria_path: Path = CRITERIA_PATH) -> None:
+        with criteria_path.open(encoding="utf-8") as f:
+            self.criteria: Dict[str, Dict[str, float]] = json.load(f)
+
+    def check(self, gpa: float, qudrat: float, tahseely: float, ielts: float) -> EligibilityResult:
+        """Return eligibility result for the given scores."""
+        eng_rules = self.criteria.get("engineering", {})
+        non_eng_rules = self.criteria.get("non_engineering", {})
+
+        is_eng = (
+            gpa >= eng_rules.get("gpa", float("inf"))
+            and qudrat >= eng_rules.get("qudrat", float("inf"))
+            and tahseely >= eng_rules.get("tahseely", float("inf"))
+            and ielts >= eng_rules.get("ielts", float("inf"))
+        )
+        if is_eng:
+            return EligibilityResult(True, "engineering")
+
+        is_non_eng = (
+            gpa >= non_eng_rules.get("gpa", float("inf"))
+            and qudrat >= non_eng_rules.get("qudrat", float("inf"))
+            and tahseely >= non_eng_rules.get("tahseely", float("inf"))
+            and ielts >= non_eng_rules.get("ielts", float("inf"))
+        )
+        if is_non_eng:
+            return EligibilityResult(True, "non_engineering")
+
+        return EligibilityResult(False, None)
+
+
+def check_eligibility(gpa: float, qudrat: float, tahseely: float, ielts: float) -> EligibilityResult:
+    """Convenience wrapper around :class:`EligibilityEngine`."""
+    engine = EligibilityEngine()
+    return engine.check(gpa, qudrat, tahseely, ielts)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The `PromptMaster_AdmiFlowPMU_v2025Q.json` file provides system instructions and
 ```bash
 .
 ├── app.py                     # Streamlit web interface
+├── EligibilityCalculator.json  # Admission criteria rules
+├── EligibilityEngine.py        # Python eligibility evaluator
 ├── run_prompt.py              # CLI/Streamlit runner
 ├── main.py                    # CLI prompt helper
 ├── sharepoint_upload.py       # SharePoint integration helper

--- a/tests/test_eligibility_engine.py
+++ b/tests/test_eligibility_engine.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+# Ensure repo root in path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from EligibilityEngine import check_eligibility, EligibilityEngine, EligibilityResult
+
+
+def test_engineering_eligible():
+    result = check_eligibility(gpa=90, qudrat=70, tahseely=70, ielts=6.5)
+    assert result == EligibilityResult(True, "engineering")
+
+
+def test_non_engineering_eligible():
+    engine = EligibilityEngine()
+    res = engine.check(gpa=82, qudrat=61, tahseely=62, ielts=6.0)
+    assert res.eligible and res.track == "non_engineering"
+
+
+def test_not_eligible():
+    res = check_eligibility(gpa=70, qudrat=50, tahseely=50, ielts=5.0)
+    assert res == EligibilityResult(False, None)


### PR DESCRIPTION
## Summary
- introduce JSON-based admission criteria
- implement `EligibilityEngine` for evaluating candidate scores
- document new components in README

## Testing
- `python3 tests/test_eligibility_engine.py`
- `python3 tests/test_moving_average.py` *(fails: ModuleNotFoundError: No module named 'pytest')*
- `pytest` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6891ab5b320c832090f9cbe4bc4d2993