### PR TITLE
Add modular eligibility engine for AdmiFlow-PMU

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts for AdmiFlow-PMU."""

--- a/scripts/eligibility_engine.py
+++ b/scripts/eligibility_engine.py
@@ -1,0 +1,49 @@
+"""Eligibility evaluation for AdmiFlow-PMU.
+تقييم الأهلية لنظام AdmiFlow-PMU"""
+
+from typing import Dict, List
+
+# Eligibility rules definition (English + Arabic)
+# تعريف قواعد الأهلية
+CRITERIA = [
+    ("High School Score ≥ 85%", "high_school_score", 85),
+    ("Qudurat Score ≥ 65", "qudrat_score", 65),
+    ("Tahseely Score ≥ 65", "tahseely_score", 65),
+    ("IELTS Overall ≥ 6.0", "ielts_overall", 6.0),
+    ("IELTS Writing ≥ 5.5", "ielts_writing", 5.5),
+]
+
+
+def evaluate_eligibility(scores: Dict[str, float]) -> Dict[str, object]:
+    """Return eligibility status and missing criteria.
+
+    Parameters:
+        scores: mapping of score name to value
+        Dictionary example: {
+            "high_school_score": 90,
+            "qudrat_score": 70,
+            "tahseely_score": 70,
+            "ielts_overall": 6.5,
+            "ielts_writing": 6.0,
+        }
+
+    Returns:
+        dict ready for JSON serialization
+    """
+    # Collect unmet rules
+    # جمع الشروط غير المستوفاة
+    missing: List[str] = []
+    for label, key, minimum in CRITERIA:
+        # Retrieve student's score; default to 0 if missing
+        # جلب درجة الطالب؛ القيمة الافتراضية 0 في حال عدم توفرها
+        value = scores.get(key, 0)
+        if value < minimum:
+            missing.append(label)
+
+    # Determine final status based on missing criteria
+    # تحديد الحالة النهائية بناءً على الشروط الناقصة
+    status = "Qualified" if not missing else "Not Qualified"
+
+    # Return JSON-ready result
+    # إرجاع النتيجة بصيغة جاهزة لـ JSON
+    return {"Status": status, "MissingCriteria": missing}

--- a/tests/test_scripts_eligibility_engine.py
+++ b/tests/test_scripts_eligibility_engine.py
@@ -1,0 +1,31 @@
+from scripts.eligibility_engine import evaluate_eligibility
+
+
+def test_all_criteria_met():
+    scores = {
+        "high_school_score": 90,
+        "qudrat_score": 70,
+        "tahseely_score": 70,
+        "ielts_overall": 6.5,
+        "ielts_writing": 6.0,
+    }
+    result = evaluate_eligibility(scores)
+    assert result["Status"] == "Qualified"
+    assert result["MissingCriteria"] == []
+
+
+def test_missing_criteria():
+    scores = {
+        "high_school_score": 80,
+        "qudrat_score": 60,
+        "tahseely_score": 70,
+        "ielts_overall": 5.5,
+        "ielts_writing": 5.0,
+    }
+    result = evaluate_eligibility(scores)
+    assert result["Status"] == "Not Qualified"
+    assert "High School Score ≥ 85%" in result["MissingCriteria"]
+    assert "Qudurat Score ≥ 65" in result["MissingCriteria"]
+    assert "IELTS Overall ≥ 6.0" in result["MissingCriteria"]
+    assert "IELTS Writing ≥ 5.5" in result["MissingCriteria"]
+    assert len(result["MissingCriteria"]) == 4


### PR DESCRIPTION
## Summary
- implement JSON-ready eligibility evaluator with bilingual comments
- add tests covering qualified and unqualified scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6891e342bcbc8320919424d187563eb9