### PR TITLE
Add admission engine with document verification and email hooks

### DIFF
--- a/admission_engine.py
+++ b/admission_engine.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""High-level admission engine integrating eligibility, document verification, and decision email sending.
+
+This module builds upon :class:`EligibilityEngine` and introduces placeholders that
+prepare the system for future API wrapping and integration with document verification
+and decision email generation services.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Any
+
+from EligibilityEngine import EligibilityEngine, EligibilityResult
+
+
+@dataclass
+class ApplicationData:
+    """Container for application scores."""
+
+    gpa: float
+    qudrat: float
+    tahseely: float
+    ielts: float
+
+
+class AdmissionEngine:
+    """Coordinate full admission workflow."""
+
+    def __init__(self, eligibility_engine: EligibilityEngine | None = None) -> None:
+        # محرك الأهلية الأساسي | Underlying eligibility engine
+        self.eligibility_engine = eligibility_engine or EligibilityEngine()
+
+    def verify_documents(self, documents: Dict[str, Any]) -> bool:
+        """Verify provided documents.
+
+        التحقق من اكتمال المستندات – Return ``True`` if every required document has data.
+        """
+        # التحقق من المستندات المقدمة | Validate supplied documents
+        return all(bool(data) for data in documents.values())
+
+    def send_decision_email(self, email: str, result: EligibilityResult) -> None:
+        """Send admission decision via email.
+
+        إرسال قرار القبول عبر البريد الإلكتروني – Placeholder for future integration with
+        decision email generator service.
+        """
+        # إرسال بريد القرار | Send decision email
+        print(f"Sending decision to {email}: eligible={result.eligible}, track={result.track}")
+
+    def process_application(self, application: ApplicationData, documents: Dict[str, Any], email: str) -> EligibilityResult:
+        """Process full application flow.
+
+        معالجة طلب القبول بالكامل – Verifies documents, evaluates eligibility, then sends
+        decision email. Designed for future API wrapping.
+        """
+        # خطوة 1: التحقق من المستندات | Step 1: verify documents
+        if not self.verify_documents(documents):
+            return EligibilityResult(False, None)
+
+        # خطوة 2: تقييم الأهلية | Step 2: evaluate eligibility
+        result = self.eligibility_engine.check(
+            application.gpa,
+            application.qudrat,
+            application.tahseely,
+            application.ielts,
+        )
+
+        # خطوة 3: إرسال القرار | Step 3: send decision email
+        self.send_decision_email(email, result)
+
+        return result

--- a/tests/test_admission_engine.py
+++ b/tests/test_admission_engine.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+# Ensure repo root in path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from admission_engine import AdmissionEngine, ApplicationData
+
+
+def test_verify_documents():
+    engine = AdmissionEngine()
+    assert engine.verify_documents({'id': '123', 'transcript': 'data'})
+    assert not engine.verify_documents({'id': '123', 'transcript': ''})
+
+
+def test_process_application(monkeypatch):
+    engine = AdmissionEngine()
+    app = ApplicationData(gpa=90.0, qudrat=70.0, tahseely=70.0, ielts=6.5)
+    docs = {'id': '1', 'transcript': 'file'}
+
+    captured = {}
+
+    def fake_send(email, result):
+        captured['email'] = email
+        captured['result'] = result
+
+    # استبدال وظيفة إرسال البريد | Replace the email send function
+    monkeypatch.setattr(engine, 'send_decision_email', fake_send)
+
+    result = engine.process_application(app, docs, 'user@example.com')
+    assert result.eligible
+    assert captured['email'] == 'user@example.com'
+    assert captured['result'].eligible


### PR DESCRIPTION
## Summary
- add high-level AdmissionEngine with placeholders for document verification and decision email generation
- include bilingual (Arabic/English) comments to prep for future API exposure
- cover new engine with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891e60b9088832097ec2d15bf6b0aad