### PR TITLE
Add program eligibility engine with alternative suggestions

### DIFF
--- a/scripts/program_rules.json
+++ b/scripts/program_rules.json
@@ -1,0 +1,14 @@
+{
+  "Engineering": {
+    "high_school": 85,
+    "qudrat": 65,
+    "tahseely": 65,
+    "ielts": 6.0
+  },
+  "Business": {
+    "high_school": 80,
+    "qudrat": 60,
+    "tahseely": 60,
+    "ielts": 6.0
+  }
+}

--- a/tests/test_scripts_eligibility_engine.py
+++ b/tests/test_scripts_eligibility_engine.py
@@ -1,31 +1,43 @@
 from scripts.eligibility_engine import evaluate_eligibility
 
 
-def test_all_criteria_met():
-    scores = {
-        "high_school_score": 90,
-        "qudrat_score": 70,
-        "tahseely_score": 70,
-        "ielts_overall": 6.5,
-        "ielts_writing": 6.0,
+def test_engineering_qualified():
+    applicant = {
+        "program": "Engineering",
+        "high_school": 90,
+        "qudrat": 70,
+        "tahseely": 70,
+        "ielts": 6.5,
     }
-    result = evaluate_eligibility(scores)
+    result = evaluate_eligibility(applicant)
     assert result["Status"] == "Qualified"
     assert result["MissingCriteria"] == []
+    assert result["SuggestedPrograms"] == []
 
 
-def test_missing_criteria():
-    scores = {
-        "high_school_score": 80,
-        "qudrat_score": 60,
-        "tahseely_score": 70,
-        "ielts_overall": 5.5,
-        "ielts_writing": 5.0,
+def test_missing_criteria_with_alternative():
+    applicant = {
+        "program": "Engineering",
+        "high_school": 80,
+        "qudrat": 65,
+        "tahseely": 60,
+        "ielts": 6.0,
     }
-    result = evaluate_eligibility(scores)
+    result = evaluate_eligibility(applicant)
     assert result["Status"] == "Not Qualified"
-    assert "High School Score ≥ 85%" in result["MissingCriteria"]
-    assert "Qudurat Score ≥ 65" in result["MissingCriteria"]
-    assert "IELTS Overall ≥ 6.0" in result["MissingCriteria"]
-    assert "IELTS Writing ≥ 5.5" in result["MissingCriteria"]
-    assert len(result["MissingCriteria"]) == 4
+    assert "High School % ≥ 85" in result["MissingCriteria"]
+    assert "Tahseely Score ≥ 65" in result["MissingCriteria"]
+    assert "Business" in result["SuggestedPrograms"]
+
+
+def test_not_qualified_any_program():
+    applicant = {
+        "program": "Engineering",
+        "high_school": 70,
+        "qudrat": 50,
+        "tahseely": 40,
+        "ielts": 5.0,
+    }
+    result = evaluate_eligibility(applicant)
+    assert result["Status"] == "Not Qualified"
+    assert result["SuggestedPrograms"] == []


### PR DESCRIPTION
## Summary
- expand eligibility evaluation to load program-specific rules from JSON and compute missing criteria with alternative program suggestions
- define configurable program rules for Engineering and Business tracks
- cover qualified, partially qualified, and unqualified cases in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891e5e682d08320be853119d0d9e1cf