### PR TITLE
fix: export application data

### DIFF
--- a/routes/application.js
+++ b/routes/application.js
@@ -67,3 +67,7 @@ router.get('/admin/applications', (req, res) => {
 });
 
 module.exports = router;
+
+// 🛠️ إتاحة البيانات المشتركة لمسارات المسؤول
+module.exports.applications = applications;
+module.exports.documents = documents;


### PR DESCRIPTION
## Summary
- expose in-memory application data so admin routes can access submissions

## Testing
- `npm test` *(fails: Missing script "test")*
- Started server and exercised admin update endpoint

------
https://chatgpt.com/codex/tasks/task_e_688e1ca447b88320870fa8f7f9a1bc1e